### PR TITLE
Fix for forced disconnect handling

### DIFF
--- a/core/init.sqf
+++ b/core/init.sqf
@@ -15,7 +15,6 @@ if (isServer) then {
 	FW_EventPlayerSpawnedHandle = ["FW_PlayerSpawned", {_this call FNC_EventPlayerSpawned;}] call CBA_fnc_addEventHandler;
 	FW_EventRespawnedHandle = addMissionEventHandler ["EntityRespawned", {_this call FNC_EventRespawned;}];
 	FW_EventKilledHandle = addMissionEventHandler ["EntityKilled", {_this call FNC_EventKilled;}];
-	FW_EventDisconnectHandle = addMissionEventHandler ["HandleDisconnect", {_this call FNC_EventDisconnect;}];
 	
 };
 


### PR DESCRIPTION
Basically removes the forced removal of disconnect bodies. If there are changes to the core it should be discussed between all maintainers of the framework. If it is a module it is fine.

The entire disconnect thing should only be handled by the module so the mission maker can decide himself if he wants to remove bodies.

We should argue about wether we should add "mission start dead body removal" to the core of the framework or add it to the module.