### PR TITLE
Module / Jip - Changed default variable

### DIFF
--- a/modules/jip/settings.sqf
+++ b/modules/jip/settings.sqf
@@ -23,7 +23,7 @@ switch (side player) do {
 	case east: {
 		//JIPTYPE
 		//How should JIPs be handled, options are: DENY: Player is killed and put in spectator. TELEPORT: Player can teleport to his squad. TRANSPORT: Player can send a hint to all group leaders requesting transport.
-		FW_JIPTYPE = "TRANSPORT";
+		FW_JIPTYPE = "TELEPORT";
 
 		//JIPDISTANCE
 		//When you spawn, if your squad members are more then JIPDISTANCE away, you get the option to teleport or request transport.
@@ -37,15 +37,15 @@ switch (side player) do {
 	case independent: {
 		//JIPTYPE
 		//How should JIPs be handled, options are: DENY: Player is killed and put in spectator. TELEPORT: Player can teleport to his squad. TRANSPORT: Player can send a hint to all group leaders requesting transport.
-		FW_JIPTYPE = "DENY";
+		FW_JIPTYPE = "TELEPORT";
 
 		//JIPDISTANCE
 		//When you spawn, if your squad members are more then JIPDISTANCE away, you get the option to teleport or request transport.
-		FW_JIPDISTANCE = 0;
+		FW_JIPDISTANCE = 50;
 
 		//SPAWNDISTANCE
 		//If you move SPAWNDISTANCE away from your spawn position you loose the option to teleport or request transport.
-		FW_SPAWNDISTANCE = 0;
+		FW_SPAWNDISTANCE = 200;
 	};
 
 };


### PR DESCRIPTION
Changed Independent from DENY to TELEPORT, as I see to many missions say
they have JIP Teleport, jet they dont, due to the MM never changed the
settings for it.